### PR TITLE
Pkg tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Manifest.toml
 
 # Silly macOS stuff
 .DS_Store
+
+# VS Code folder
+.vscode

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,12 +4,12 @@
     "${BASH_SOURCE[0]}" "$@"
     =#
 
-include(joinpath(dirname(dirname(@__FILE__)), "src", "SpelledOut.jl"))
+#include(joinpath(dirname(dirname(@__FILE__)), "src", "SpelledOut.jl"))
 
-using .SpelledOut
 using Test
+using SpelledOut
 
-@testset "SpelledOut.jl" begin
+@testset "English" begin
 ### ENGLISH TESTS
     @test spelled_out(1234, lang = :en) == "one thousand, two hundred thirty-four"
     @test spelled_out(1234) == "one thousand, two hundred thirty-four" # default to english
@@ -32,3 +32,5 @@ using Test
     @test spelled_out(3, lang = :en) == "three"
     @test spelled_out(3.141592653, lang = :en) == "three point one four one five nine two six five three"
 end
+
+nothing


### PR DESCRIPTION
Hi, I just added a project to `test/` with

```julia
pkg> activate ./test
pkg> add Test
```

This creates a `test/Project.toml` and a `test/Manifest.toml`, although `.gitignore` is configured to ignore `Manifest.toml`.

Now `runtest.jl` works simply with `using SpelledOut`.

You test as before. Either clicking to run `runtests.jl` in VS Code, which is what I do, or in the REPL with

```julia
pkg> activate .
pkg> test
```
