### PR TITLE
Fix deprecation warning on Formatting.jl package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpelledOut"
 uuid = "4728c690-e668-4265-bc0d-51a8c0f93067"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com> and contributors"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"

--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,11 @@ version = "1.2.0"
 
 [deps]
 DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"
-Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
+Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
 
 [compat]
 DecFP = "1.1"
-Formatting = "0.4"
+Format = "1.3"
 julia = "1"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,9 @@
 [deps]
 DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
+Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+
+[compat]
+DecFP = "1.1"
+Format = "1.3"
+julia = "1"

--- a/src/SpelledOut.jl
+++ b/src/SpelledOut.jl
@@ -1,7 +1,7 @@
 module SpelledOut
 
 using DecFP: Dec64, Dec128
-using Formatting: format
+using Format: format
 
 export spelled_out, Spelled_out, Spelled_Out, SPELLED_OUT
 
@@ -64,9 +64,9 @@ function spelled_out(
     elseif lang ∈ (:pt,)
         return spelled_out_pt(number; portugal = true, dict = dict)
     end
-    
+
     throw(error("We do not support $lang yet.  Please make an issue and someone might be able to help you, or feel free to contribute."))
-    
+
     return nothing
 end
 


### PR DESCRIPTION
When installing SpelledOut.jl in a new Julia environment, a deprecation warning by the Formatting.jl package is given.

As can be see in [its repository](https://github.com/JuliaIO/Formatting.jl), the package is deprecated and should be interchanged with the more modern Format.jl package [from here](https://github.com/JuliaString/Format.jl).

This branch fixes that deprecation warning by changing both packages. The only imported function from `Formatting.jl` was `format`. The same syntax holds for the `Format.jl` so no further changes must be made. The branch passed all the tests locally.