### PR TITLE
Fix spelled out function for negatives in English

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpelledOut"
 uuid = "4728c690-e668-4265-bc0d-51a8c0f93067"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com> and contributors"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"

--- a/src/en.jl
+++ b/src/en.jl
@@ -84,7 +84,13 @@ function _spelled_out_en!(io::IOBuffer, number_norm::Integer; british::Bool = fa
     end
     
     if number_norm < 0
+        # In "Merriam-Webster's Guide to Everyday Math: A Home and Business Reference"
+        # by Brian Burrell (1998), the adjective "negative" over "minus" is used for
+        # negative numbers.
+        #
+        # See #40: SpelledOut.jl/issues/40
         print(io, "negative ")
+        number_norm = abs(number_norm)
     end
 	
     if number_norm > limit - 1
@@ -223,7 +229,7 @@ function spelled_out_en(number::Rational; british::Bool = false, dict::Symbol = 
 	word = spelled_out_en(_num, british = british, dict = dict) * " " * spell_ordinal_en(_den, british = british, dict = dict)
     
     # account for pluralisation
-	return isone(_num) ? word : word * "s"
+    return isone(abs(_num)) ? word : word * "s"
 end
 
 function spelled_out_en(number::AbstractIrrational; british::Bool = false, dict::Symbol = :modern)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,9 @@ using SpelledOut
     @test spelled_out(2^log2(3390000), lang = :en) == "three million, three hundred ninety thousand" # should convert 3.3899999999999986e6 to an integer
     @test spelled_out(1000000.01, lang = :en) == "one million point zero one" # parse big floats correctly (i.e., avoid scientific notation.  Caveat: this is slow)
     @test spelled_out(1//3, lang = :en_UK) == "one third"
+    @test spelled_out(2//3, lang = :en_UK) == "two thirds"
     @test spelled_out(1//5, lang = :en_UK) == "one fifth"
+    @test spelled_out(2//5, lang = :en_UK) == "two fifths"
     @test spelled_out(1//102, lang = :en_UK) == "one one hundred and second"
     @test spelled_out(1//102, lang = :en_US) == "one one hundred second"
     @test spelled_out(5//102, lang = :en_UK) == "five one hundred and seconds"
@@ -31,6 +33,18 @@ using SpelledOut
     @test spelled_out(40//1, lang = :en_UK) == "forty"
     @test spelled_out(40//2, lang = :en_UK) == "twenty"
     @test spelled_out(40//6, lang = :en_UK) == "twenty thirds"
+
+    @test spelled_out(-1; lang=:en_UK) == "negative one"
+    @test spelled_out(-19; lang=:en_UK) == "negative nineteen"
+    @test spelled_out(-198; lang=:en_UK) == "negative one hundred and ninety-eight"
+    @test spelled_out(-1982; lang=:en_UK) == "negative one thousand, nine hundred and eighty-two"
+    @test spelled_out(-3.0; lang=:en_UK) == "negative three"
+    @test spelled_out(-1//3; lang=:en_UK) == "negative one third"
+    @test spelled_out(-(1//3); lang=:en_UK) == "negative one third"
+    @test spelled_out(-3//1; lang=:en_UK) == "negative three"
+    @test spelled_out(-(3//1); lang=:en_UK) == "negative three"
+    @test spelled_out(3//-1; lang=:en_UK) == "negative three"
+    @test spelled_out(Complex(-2, -3); lang=:en_UK) == "negative two and negative three imaginaries"
 end
 
 @testset "Spanish" begin


### PR DESCRIPTION
Negative numbers were not spelled out properly for small numbers or for rationals