### PR TITLE
Add generic type fallback for multiple dispatch!  v1.2.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpelledOut"
 uuid = "4728c690-e668-4265-bc0d-51a8c0f93067"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com> and contributors"]
-version = "1.2.3"
+version = "1.2.4"
 
 [deps]
 DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"

--- a/src/es.jl
+++ b/src/es.jl
@@ -92,7 +92,7 @@ function es_spell_large(_number)
 end
 
 
-function spelled_out_es(number; dict=:standard)
+function spelled_out_es(number::Union{Integer, Float64}; dict=:standard)
     if iszero(number)
         return "cero"
     end
@@ -135,3 +135,7 @@ end
 
 
 
+# Fallback method if we do not know how to handle the input
+function spelled_out_es(number, dict = :standard)
+    throw(error("Cannot parse type $(typeof(number)).  Please make an issue."))
+end

--- a/src/pt.jl
+++ b/src/pt.jl
@@ -120,7 +120,7 @@ function pt_spell_large( _number; portugal::Bool = false )
     return res
 end
 
-function spelled_out_pt( number; portugal::Bool = false, dict::Symbol = :standard )
+function spelled_out_pt( number::Union{Integer, Float64}; portugal::Bool = false, dict::Symbol = :standard )
     if iszero( number )
         return "zero"
     end
@@ -156,3 +156,7 @@ function spelled_out_pt( number; portugal::Bool = false, dict::Symbol = :standar
 end
 
 
+# Fallback method if we do not know how to handle the input
+function spelled_out_pt(number; portugal::Bool = false, dict::Symbol = :standard)
+    throw(error("Cannot parse type $(typeof(number)).  Please make an issue."))
+end

--- a/src/ru.jl
+++ b/src/ru.jl
@@ -1,3 +1,9 @@
 function spelled_out_ru(number::Number)
     
+
+end
+
+# Fallback method if we do not know how to handle the input
+function spelled_out_ru(number)
+    throw(error("Cannot parse type $(typeof(number)).  Please make an issue."))
 end


### PR DESCRIPTION
When you call spelled_out with an unknown number type, it should tell you that it's not supported, rather than doing the Pythonic thing of trying to use it until it fails with a poor error message.  Multiple dispatch is very convenient to use in this case, but we need to specify the fallback function manually.  This is what is implemented in this version of SpelledOut.jl

See merge request #61